### PR TITLE
Bumped the acceptable versions of Click.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     name="vinnie",
     version="0.8.0",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    install_requires=["Click>=7.1,<7.2", "semver==2.13.0", "GitPython==3.1.13"],
+    install_requires=["Click>=7.1,<9.0", "semver==2.13.0", "GitPython==3.1.13"],
     tests_require=["pytest==5.0.1", "pytest-sugar==0.9.2", "pytest-cov==2.7.1"],
     setup_requires=["pytest-runner"],
     long_description=readme,


### PR DESCRIPTION
Current versions of Celery require `Click>=8.0,<9.0`, which conflicts with `vinnie`'s current version requirements.

The rationale seems to be because of `django-click`, but they dropped that range requirement - https://github.com/GaretJax/django-click/commit/2aad26cd51b128decbe1598b3aff40879474ea00

I believe it should be OK to upgrade this, and tests are passing locally.

```
$ pytest tests
# ...
31 passed, 60 warnings in 2.85s
```